### PR TITLE
Fix: generate macfand.service in PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -46,6 +46,7 @@ package() {
 	install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
 	install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
 	install -Dm644 macfand.1 "${pkgdir}/usr/share/man/man1/macfand.1"
+	sh macfand.service.gen > macfand.service
 	install -Dm644 macfand.service "${pkgdir}/usr/lib/systemd/system/macfand.service"
 
 	sudo perl ./util/updatemodel.pl "${pkgdir}/etc/macfand.conf" "${pkgdir}/usr/local/${pkgname/-git/}/machines/"


### PR DESCRIPTION
Bugfix for PKGBUILD to work:
```
==> Starting package()...
install: cannot stat 'macfand.service': No such file or directory
==> ERROR: A failure occurred in package().
    Aborting...
 -> error making: macfand-git-exit status 4
 -> Failed to install the following packages. Manual intervention is required:
macfand-git - exit status 4
```